### PR TITLE
Use luxon.js instead of moment.js (deprecated)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "cidr-regex": "^3.1.1",
     "dotenv": "^8.2.0",
     "element-ui": "^2.9.1",
-    "moment": "^2.29.1",
+    "luxon": "^1.27.0",
     "typeface-lato": "^0.0.54",
     "vue": "^2.5.21",
     "vue-i18n": "^8.11.2",

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -112,7 +112,7 @@ import router from "@/router";
 import Tal from "@/components/Tal";
 import ValidityTable from "@/components/ValidityTable";
 const cidrRegex = require("cidr-regex");
-import * as moment from "moment";
+import { DateTime } from "luxon";
 
 export default {
   components: {
@@ -207,10 +207,10 @@ export default {
       this.validatePrefix();
     },
     getTimestamp(timestamp) {
-      return moment.utc(timestamp).format() + " UTC";
+      return DateTime.fromISO(timestamp, { zone: "utc"}).toFormat('yyyy-MM-dd TTT');
     },
     fromNow(timestamp) {
-      return moment.utc(timestamp).fromNow();
+      return DateTime.fromISO(timestamp, { zone: "utc"}).toRelative();
     }
   }
 };


### PR DESCRIPTION
Reimplements the validation dates with luxon. Also gets rid of the redundant 'Z' at the end of the datetime string.