### PR TITLE
Remove the API_HOST runtime configuration again

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,22 +79,6 @@ The API hosts to use can be specified at runtime or at build time. By default
 the current host is used for the Routinator API endpoints and https://rest.bgp-api.net
 for the Roto API.
 
-### Runtime
-
-The `index.html` file contains the following fragment:
-
-```javascript
-    window.ROTO_API_HOST = 'ROTO_API_HOST_PLACEHOLDER';
-    window.ROUTINATOR_API_HOST = 'ROUTINATOR_API_HOST_PLACEHOLDER';
-```
-
-The respective endpoints can be configured by replacing the string
-`ROTO_API_HOST_PLACEHOLDER` and/or the string `ROUTINATOR_API_HOST_PLACEHOLDER`
-before serving the content of `index.html`. If these are not configured at runtime
-the build time variables or the defaults will be used.
-
-### Build time
-
 By specifying `ROTO_API_HOST` and/or `ROUTINATOR_API_HOST` as environment variables
 these can be configured at build time. For example:
 

--- a/index.html
+++ b/index.html
@@ -6,10 +6,6 @@
     <meta name="description" content="User interface for Routinator. Perform a Prefix Check, view detailed statistics from the last validation run Routinator has performed and HTTP and RTR connection metrics." />
     <title>Routinator</title>
     <link rel="icon" href="/src/img/favicon.ico">
-    <script>
-      window.ROTO_API_HOST = 'ROTO_API_HOST_PLACEHOLDER';
-      window.ROUTINATOR_API_HOST = 'ROUTINATOR_API_HOST_PLACEHOLDER';
-    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/core/contants.ts
+++ b/src/core/contants.ts
@@ -1,33 +1,8 @@
-function getRotoEndpoint() {
-  if (
-    typeof window !== 'undefined' &&
-    window.ROTO_API_HOST !== 'ROTO_API_HOST_PLACEHOLDER'
-  ) {
-    return window.ROTO_API_HOST;
-  }
-
-  if (typeof ROTO_API_HOST !== 'undefined') {
-    return ROTO_API_HOST;
-  }
-
-  return 'https://rest.bgp-api.net';
-}
-
-// public endpoint: https://routinator.do.nlnetlabs.nl
-function getApiEndpoint() {
-  if (
-    typeof window !== 'undefined' &&
-    window.ROUTINATOR_API_HOST !== 'ROUTINATOR_API_HOST_PLACEHOLDER'
-  ) {
-    return window.ROUTINATOR_API_HOST;
-  }
-
-  if (typeof ROUTINATOR_API_HOST !== 'undefined') {
-    return ROUTINATOR_API_HOST;
-  }
-
-  return '';
-}
-
-export const ROTO_ENDPOINT = getRotoEndpoint();
-export const API_ENDPOINT = getApiEndpoint();
+export const ROTO_ENDPOINT =
+  typeof ROTO_API_HOST === 'undefined'
+    ? 'https://rest.bgp-api.net'
+    : ROTO_API_HOST;
+export const API_ENDPOINT =
+  typeof ROUTINATOR_API_HOST === 'undefined'
+    ? 'https://routinator.do.nlnetlabs.nl'
+    : ROUTINATOR_API_HOST;

--- a/src/types.ts
+++ b/src/types.ts
@@ -207,9 +207,3 @@ export interface RouteIdent {
   max_length: string;
 }
 
-declare global {
-  interface Window {
-    ROUTINATOR_API_HOST: string;
-    ROTO_API_HOST: string;
-  }
-}


### PR DESCRIPTION
This PR removed the ROTO_API_HOST and ROUTINATOR_API_HOST runtime configuration mechanism. Instead we will be recommending for people with special requirements to build and run their own version.