### PR TITLE
Fix href in nav bar

### DIFF
--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -40,9 +40,10 @@ export default function Link({
     }
     navigate(targetRouteName, targetParams);
   };
+  const displayPath = `.${route.path}`;
 
   return (
-    <a {...props} href={route.path} className={fullClassName} onClick={click}>
+    <a {...props} href={displayPath} className={fullClassName} onClick={click}>
       {props.children || route.label}
     </a>
   );

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
-  base: '/',
+  base: '/ui/',
   define: {
     APP_VERSION: JSON.stringify(process.env.npm_package_version),
     ROUTINATOR_API_HOST: JSON.stringify(process.env.ROUTINATOR_API_HOST),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
-  base: '/ui/',
+  base: '/',
   define: {
     APP_VERSION: JSON.stringify(process.env.npm_package_version),
     ROUTINATOR_API_HOST: JSON.stringify(process.env.ROUTINATOR_API_HOST),


### PR DESCRIPTION
This PR aims to fix the issue that the href of the items in the navbar refer to /metrics rather than /ui/metrics. Navigation itself worked fine, unless the link is opened in a new window or tab, in which case it would show a 404.
![image](https://github.com/NLnetLabs/routinator-ui/assets/5168825/8589e78f-bf1e-4d19-ae1c-8e1b7fcbdfde)
