### PR TITLE
Do not attempt to use bad request replies in prefix check

### DIFF
--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -227,7 +227,7 @@ export default function useSearch(
           const validateResponse = await fetch(
             `${API_ENDPOINT}/api/v1/validity/${asn}/${nextPrefix}`
           );
-           if (validateResponse.status >= 400) {
+          if (validateResponse.status >= 400) {
             console.warn(`Fetching ${API_ENDPOINT}/api/v1/validity/${asn}/${nextPrefix} failed`);
             continue;
           }

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -217,6 +217,10 @@ export default function useSearch(
         const validateResponse = await fetch(
           `${API_ENDPOINT}/api/v1/validity/${asn}/${nextPrefix}`
         );
+        if (validateResponse.status >= 400) {
+          console.warn(`Fetching ${API_ENDPOINT}/api/v1/validity/${asn}/${nextPrefix} failed`);
+          continue;
+        }
         res.push(await validateResponse.json());
       }
       setValidationResults(res);


### PR DESCRIPTION
As reported in #66 - prefixes of certain sizes cause Routinator to return a `Bad Request` with the text `Bad Request` as string in the body, which the UI cannot handle.

@partim Do you want to change the behaviour in Routinator as well, or is fixing it in the UI sufficient?