### PR TITLE
Add searching for only an ASN

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,8 @@ Breaking changes
 
 New
 
+* Search by ASN only. Entering a prefix is now optional. ([#71])
+
 Bug fixes
 
 * Fixed the label for the HTTP connection status metrics. ([#65] by
@@ -16,6 +18,7 @@ Other changes
 
 [#65]: https://github.com/NLnetLabs/routinator-ui/pull/65
 [#69]: https://github.com/NLnetLabs/routinator-ui/pull/69
+[#71]: https://github.com/NLnetLabs/routinator-ui/pull/71
 [@beatjoerg]: https://github.com/beatjoerg
 
 

--- a/src/components/prefix-check/RelatedPrefixesGroups.tsx
+++ b/src/components/prefix-check/RelatedPrefixesGroups.tsx
@@ -33,15 +33,16 @@ export default function RelatedPrefixesGroups({
       <h3>Related Prefixes</h3>
       <p>
         Best Matching Prefix in Allocations and/or BGP
-        <span className="tag">Region {rir}</span>
+        {rir && <span className="tag">Region {rir}</span>}
       </p>
+      {search.result.prefix && 
       <RelatedTable
         members={[search.result]}
         highlight={highlight}
         showAllocated={true}
         setNotification={setNotification}
         showFilter={false}
-      />
+      />}
       <RelatedPrefixes
         type="more-specific"
         label="more specific"
@@ -64,6 +65,15 @@ export default function RelatedPrefixesGroups({
         type="same-org"
         label="allocated to the same organization"
         param="related_alloc"
+        highlight={highlight}
+        showAllocated={false}
+        relations={search.result.relations}
+        setNotification={setNotification}
+      />
+      <RelatedPrefixes
+        type="bgp-origin-asn"
+        label="same origin ASN"
+        param="related_asn"
         highlight={highlight}
         showAllocated={false}
         relations={search.result.relations}

--- a/src/components/prefix-check/RelatedTableRow.tsx
+++ b/src/components/prefix-check/RelatedTableRow.tsx
@@ -41,7 +41,7 @@ export default function RelatedTableRow({
           )}
         </td>
         <td className="prefix-container">
-          <Link params={{ prefix, 'validate-bgp': 'true' }}>{prefix}</Link>
+          <Link params={{ prefix, 'validate-bgp': 'true', 'asns': asn ?? "" }}>{prefix}</Link>
           {isAllocated && <span className="tag">Allocated</span>}
         </td>
         <td className={highlightAsn ? 'higlighted' : ''}>

--- a/src/components/prefix-check/SearchForm.tsx
+++ b/src/components/prefix-check/SearchForm.tsx
@@ -29,7 +29,7 @@ export default function SearchForm({
       }}
     >
       <p>
-        <label htmlFor="prefix">Prefix or IP Address</label>
+        <label htmlFor="prefix">Prefix or IP Address (optional)</label>
         <input
           type="text"
           onChange={(e) => setPrefix(e.target.value)}

--- a/src/components/prefix-check/ValidationResult.tsx
+++ b/src/components/prefix-check/ValidationResult.tsx
@@ -23,6 +23,11 @@ export default function ValidationResult({
     );
   }
 
+  if (validationResults.length == 0) {
+    // This is the case when we only check for ASNs without prefix
+    return (<div id="validation results" />);
+  }
+
   return (
     <div id="validation-results">
       <h3>Validation</h3>

--- a/src/core/contants.ts
+++ b/src/core/contants.ts
@@ -4,5 +4,5 @@ export const ROTO_ENDPOINT =
     : ROTO_API_HOST;
 export const API_ENDPOINT =
   typeof ROUTINATOR_API_HOST === 'undefined'
-    ? ''
+    ? 'https://nate.nlnetlabs.nl'
     : ROUTINATOR_API_HOST;

--- a/src/core/util.ts
+++ b/src/core/util.ts
@@ -27,6 +27,13 @@ export function isValidASN(asn: string): boolean {
   return false;
 }
 
+export function parseASN(asn: string): number {
+  if (asn.toLowerCase().startsWith('as')) {
+    return parseInt(asn.slice(2), 10);
+  }
+  return parseInt(asn, 10);
+}
+
 export function arrayFromCommaSeperated(commaSeparated: string): string[] {
   if (!commaSeparated) {
     return [];

--- a/src/style/prefix-check.css
+++ b/src/style/prefix-check.css
@@ -123,6 +123,7 @@
 #prefix-check .results p {
   font-size: 0.9rem;
   margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
   color: var(--dark);
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -149,7 +149,7 @@ export type RelationType =
   | 'same-org'
   | 'more-specific'
   | 'less-specific'
-  | 'bgp-origin-as';
+  | 'bgp-origin-asn';
 
 export interface Relation {
   type: RelationType;


### PR DESCRIPTION
~~Work in progress for~~ searching on an ASN only (rather than a prefix). Relates to https://github.com/NLnetLabs/routinator-ui/issues/39 

- [x] Make prefix field optional
- [x] Add sensible output for ASN
- [x] Make sure existing things have not broken

![image](https://github.com/user-attachments/assets/e2f0c9d4-1de8-4124-95cc-23da2bb17ae5)
